### PR TITLE
Improve makefile a bit

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,23 +1,25 @@
-CFLAGS = -Wall -fexceptions -lpthread -lm -O3 -fpermissive -fno-strict-aliasing
+CFLAGS += -Wall -fexceptions -pthread -lm -O3 -fpermissive -fno-strict-aliasing
 TARGET = fm_transmitter
 
+CPP=$(CCPREFIX)g++
+
 all: main.o error_reporter.o wave_reader.o stdin_reader.o transmitter.o
-	g++ $(CFLAGS) -o $(TARGET) main.o error_reporter.o wave_reader.o stdin_reader.o transmitter.o
+	$(CPP) $(CFLAGS) -o $(TARGET) main.o error_reporter.o wave_reader.o stdin_reader.o transmitter.o
 
 wave_reader.o: wave_reader.cpp wave_reader.h
-	g++ $(CFLAGS) -c wave_reader.cpp
+	$(CPP) $(CFLAGS) -c wave_reader.cpp
 
 stdin_reader.o: stdin_reader.cpp stdin_reader.h
-	g++ $(CFLAGS) -c stdin_reader.cpp
+	$(CPP) $(CFLAGS) -c stdin_reader.cpp
 
 error_reporter.o: error_reporter.cpp error_reporter.h
-	g++ $(CFLAGS) -c error_reporter.cpp
+	$(CPP) $(CFLAGS) -c error_reporter.cpp
 
 transmitter.o: transmitter.cpp transmitter.h
-	g++ $(CFLAGS) -c transmitter.cpp
+	$(CPP) $(CFLAGS) -c transmitter.cpp
 
 main.o: main.cpp
-	g++ $(CFLAGS) -c main.cpp
+	$(CPP) $(CFLAGS) -c main.cpp
 
 clean:
 	rm *.o


### PR DESCRIPTION
You can now add own CFLAGs and specify crosscompiller prefix. Using `-pthread` is more portable.
This makes cross-compilation easier, for example to build static musl based arm binary form x86 system you can now do `CCPREFIX=arm-musl-linuxeabihf- CFLAGS=-static make`