### PR TITLE
Fix logical error

### DIFF
--- a/transmitter.cpp
+++ b/transmitter.cpp
@@ -164,7 +164,7 @@ void Transmitter::play(string filename, double frequency, bool loop)
             if (loop && !forceStop) {
                 frameOffset = 0;
                 restart = true;
-                if (reader->setFrameOffset(0)) {
+                if (!reader->setFrameOffset(0)) {
                     break;
                 }
                 frames = reader->getFrames(bufferFrames, forceStop);


### PR DESCRIPTION
Fix the program not looping when option `-r` is supplied. There's a simple logical error.