### PR TITLE
Fixed the errno issue during make.

### DIFF
--- a/wave_reader.cpp
+++ b/wave_reader.cpp
@@ -30,7 +30,7 @@
     CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
     WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-
+#include <errno.h>
 #include "wave_reader.h"
 #include "error_reporter.h"
 #include <sstream>


### PR DESCRIPTION
wave_reader.cpp: In member function ‘std::vector<char>* WaveReader::readData(unsigned int, bool, bool&)’:
wave_reader.cpp:118:69: error: ‘errno’ was not declared in this scope
         if (((bytes == -1) && ((fileDescriptor != STDIN_FILENO) || (errno != EAGAIN))) ||
                                                                     ^
wave_reader.cpp:118:78: error: ‘EAGAIN’ was not declared in this scope
         if (((bytes == -1) && ((fileDescriptor != STDIN_FILENO) || (errno != EAGAIN))) ||
                                                                              ^
makefile:21: recipe for target 'wave_reader.o' failed
make: *** [wave_reader.o] Error 1